### PR TITLE
Adding block push/commit to master pre-commit script.

### DIFF
--- a/.pre-commit.sh
+++ b/.pre-commit.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+RED='\033[0;31m'
+NC='\033[0m' # No Color
+
+protected_branch='master'
+current_branch=$(git symbolic-ref HEAD | sed -e 's,.*/\(.*\),\1,')
+
+if [ $protected_branch = $current_branch ]
+then
+    printf "${RED}\nYou're trying to commit directly to master, but that's not allowed.\nPlease use the fork-and-branch workflow and submit a pull request with your changes.\n\n${NC}"
+    exit 1 > /dev/null # push will not execute
+else
+    exit 0 # push will execute
+fi


### PR DESCRIPTION
### Important!

To ensure this script is implemented, you must create a symbolic link in your local repo:

```
cd .git/hooks
ln -s ../../.pre-commit.sh pre-commit
```
